### PR TITLE
fixes windows powershell charset error

### DIFF
--- a/dongtai_agent_python/report/upload_data.py
+++ b/dongtai_agent_python/report/upload_data.py
@@ -155,13 +155,13 @@ class AgentUpload(object):
 
     def base_report(self, url, body):
         url = self.config_data.get("iast", {}).get("server", {}).get("url", "") + url
-        print(body)
+        logger.debug(body)
         stream_data = json.dumps(body)
 
         body_data = gzip.compress(stream_data.encode('utf-8'))
         try:
             res = requests.post(url, data=body_data, timeout=20, headers=self.headers)
-            print(res.content)
+            logger.debug(res.content)
             Resp = res.content.decode("utf-8")
             Resp = json.loads(Resp)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.6.8\x64\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\hostedtoolcache\windows\Python\3.6.8\x64\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\flask\__main__.py", line 3, in <module>
    main()
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\flask\cli.py", line 994, in main
    cli.main(args=sys.argv[1:])
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\flask\cli.py", line 600, in main
    return super().main(*args, **kwargs)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\click\core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\click\core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\click\core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\click\core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\click\decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\click\core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\flask\cli.py", line 849, in run_command
    app = DispatchingApp(info.load_app, use_eager_loading=eager_loading)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\flask\cli.py", line 324, in __init__
    self._load_unlocked()
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\flask\cli.py", line 350, in _load_unlocked
    self._app = rv = self.loader()
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\flask\cli.py", line 410, in load_app
    app = locate_app(self, import_name, None, raise_if_not_found=False)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\flask\cli.py", line 260, in locate_app
    __import__(module_name)
  File "D:\a\dongtai-agent-python-test-actions\dongtai-agent-python-test-actions\testFlask\app.py", line 6, in <module>
    app.wsgi_app = AgentMiddleware(app.wsgi_app, app)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\dongtai_agent_python\middlewares\flask_middleware.py", line 35, in __init__
    register_resp = self.agent_upload.agent_register(cur_middle)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\dongtai_agent_python\report\upload_data.py", line 245, in agent_register
    Resp = self.base_report(url, register_data)
  File "C:\Users\runneradmin\AppData\Roaming\Python\Python36\site-packages\dongtai_agent_python\report\upload_data.py", line 158, in base_report
    print(body)
  File "C:\hostedtoolcache\windows\Python\3.6.8\x64\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u65e0' in position 365: character maps to <undefined>
```

change print to logger.debug